### PR TITLE
Date not set correctly

### DIFF
--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -32,8 +32,8 @@ angular.module('pickadate').directive('pickADate', function () {
                             scope.pickADate = new Date(0);
                         }
                         scope.pickADate.setYear(select.obj.getFullYear());
-                        scope.pickADate.setMonth(select.obj.getMonth());
                         scope.pickADate.setDate(select.obj.getDate());
+                        scope.pickADate.setMonth(select.obj.getMonth());
                     });
                 },
                 onClose: function () {


### PR DESCRIPTION
Small fix that corrects the order in which the selected date is set. This fixes a problem in which the selected date is a full month ahead of the intended one for certain dates. For example selecting February 14th 2015 shows March 14th, 2015.
