### PR TITLE
Ensure that correct date is set when selecting the 31st in month

### DIFF
--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -34,8 +34,8 @@
                 model.pickADate.assign(scope, date);
               }
               date.setYear(select.obj.getFullYear());
-              date.setDate(select.obj.getDate());
               date.setMonth(select.obj.getMonth());
+              date.setDate(select.obj.getDate());
             } else {
               model.pickADate.assign(scope, select);
             }


### PR DESCRIPTION
The date is incorrectly set to the 1st in previous month, when selecting the 31st on previous month while the currently selected month only has 30 days. This commit should fix that by setting the month before the date.
