### PR TITLE
Update ng-pickadate.js

### DIFF
--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -33,9 +33,7 @@
                 date = new Date(0);
                 model.pickADate.assign(scope, date);
               }
-              date.setYear(select.obj.getFullYear());
-              date.setMonth(select.obj.getMonth());
-              date.setDate(select.obj.getDate());
+              date.setFullYear(select.obj.getFullYear(), select.obj.getMonth(), select.obj.getDate());
             } else {
               model.pickADate.assign(scope, select);
             }


### PR DESCRIPTION
- Use the full parameters for setFullYear: dateObj.setFullYear(yearValue[, monthValue[, dayValue]]). This avoids the issuing of setting month and date in the proper order, both of which has issues when placed first, as supported with the following scenarios:

Scenario 1, setMonth(), then setDate() = wrong month:
    1. 12/31 (e.g. null dates are set new date(0) = Dec 31 in some timezones)
    2. Set month to November (only days). Date becomes 12/01, not 11/31.

Scenario 2, setDate(), then setMonth() = wrong date:
    1. 11/01 (any valid date: 1-30)
    2. Set date to the 31st. Date becomes 12/01, not 11/31.
- Plus replacing, setYear with setFullYear since setYear is deprecated.
