### PR TITLE
Fixing ng-validation states

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ If you find yourself setting the same options for multiple date pickers, you can
     }]);
   ```
 
+### ngModel / Angular Form Validation Expectation Management
+
+In order to correct how the pickadate plugin affects `ngModel` states of its assigned input, ng-pickadate uses `ngModelController` to manually restore expected form validation states: `$pristine`, `$dirty`, `$untouched`, and `$touched`. The unexpected angular validation states caused by the pickadate jQuery plugin, and how they've been corrected, are as follows:
+
+- When pickadate is initialized on an input, this triggers the input's `ngModel` to be marked as `$dirty`. -> To correct this, the ng-pickadate directives each set `ngModel` to `$pristine` at the end of the `postlink` function.
+- When pickadate calendar opens, the input itself loses focus and its `ngModel` is marked as `$touched`. -> To correct this, the directives set `ngModel` to `$untouched` the first time the calendar opens, and set it to `$touched` whenever the calendar closes, via pickadate's `onOpen` and `onClose` methods, respectively.
+
 ### Credits
 
 This project is initially based on a [blog post from Coding Insight](http://www.codinginsight.com/angularjs-and-pickadate/)

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ If you find yourself setting the same options for multiple date pickers, you can
 
 In order to correct how the pickadate plugin affects `ngModel` states of its assigned input, ng-pickadate uses `ngModelController` to manually restore expected form validation states: `$pristine`, `$dirty`, `$untouched`, and `$touched`. The unexpected angular validation states caused by the pickadate jQuery plugin, and how they've been corrected, are as follows:
 
-- When pickadate is initialized on an input, this triggers the input's `ngModel` to be marked as `$dirty`. -> To correct this, the ng-pickadate directives set `ngModel` to `$pristine` at the end of `postlink`.
-- When pickadate calendar opens, the input itself loses focus and its `ngModel` is marked as `$touched`. -> To correct this, the directives set `ngModel` to `$untouched` the first time the calendar opens, and sets to `$touched` whenever the calendar closes, via pickadate's `onOpen` and `onClose` methods, respectively.
+- When pickadate is initialized on an input, this triggers the input's `ngModel` to be marked as `$dirty`. -> To correct this, the ng-pickadate directives each set `ngModel` to `$pristine` at the end of the `postlink` function.
+- When pickadate calendar opens, the input itself loses focus and its `ngModel` is marked as `$touched`. -> To correct this, the directives set `ngModel` to `$untouched` the first time the calendar opens, and set it to `$touched` whenever the calendar closes, via pickadate's `onOpen` and `onClose` methods, respectively.
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ If you find yourself setting the same options for multiple date pickers, you can
 
 ### ngModel / Angular Form Validation Expectation Management
 
-In order to correct how the pickadate plugin affects ngModel states of its assigned input, ng-pickadate manipulates ngModel form validation in order to restore expected form validation states. The unexpected angular validation states caused by the pickadate jquery plugin, and how they've been corrected, are as follows:
+In order to correct how the pickadate plugin affects `ngModel` states of its assigned input, ng-pickadate uses `ngModelController` to manually restore expected form validation states: `$pristine`, `$dirty`, `$untouched`, and `$touched`. The unexpected angular validation states caused by the pickadate jQuery plugin, and how they've been corrected, are as follows:
 
-- When pickadate is initialized on an input, this triggers the input's ngModel to be marked as $dirty. -> To correct this, the ng-pickadate directives set ngModel to $pristine at end of (post)link.
-- When pickadate calendar opens, the input itself loses focus and its ngModel is marked as $touched. -> To correct this, the directives set ngModel to $untouched the first time the calendar opens, and sets to $touched whenever the calendar closes, via pickadate's onOpen and onClose methods, respectively.
+- When pickadate is initialized on an input, this triggers the input's `ngModel` to be marked as `$dirty`. -> To correct this, the ng-pickadate directives set `ngModel` to `$pristine` at the end of `postlink`.
+- When pickadate calendar opens, the input itself loses focus and its `ngModel` is marked as `$touched`. -> To correct this, the directives set `ngModel` to `$untouched` the first time the calendar opens, and sets to `$touched` whenever the calendar closes, via pickadate's `onOpen` and `onClose` methods, respectively.
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ If you find yourself setting the same options for multiple date pickers, you can
     }]);
   ```
 
+### Custom ngModel Form Control Status Indicators
+
+ng-pickADate doesn't cooperate with ngModel's form control status indicators, so the following custom indicators have been added:
+
+- `$pickADateUntouched` - true while date menu hasn't been (opened &) closed yet.
+- `$pickADateTouched` - true once date menu has been (opened &) closed.
+- `$pickADatePristine` - true while date hasn't been changed.
+- `$pickADateDirty` - true once date has been changed.
+
 ### Credits
 
 This project is initially based on a [blog post from Coding Insight](http://www.codinginsight.com/angularjs-and-pickadate/)

--- a/README.md
+++ b/README.md
@@ -101,15 +101,6 @@ If you find yourself setting the same options for multiple date pickers, you can
     }]);
   ```
 
-### Custom ngModel Form Control Status Indicators
-
-ng-pickADate doesn't cooperate with ngModel's form control status indicators, so the following custom indicators have been added:
-
-- `$pickADateUntouched` - true while date menu hasn't been (opened &) closed yet.
-- `$pickADateTouched` - true once date menu has been (opened &) closed.
-- `$pickADatePristine` - true while date hasn't been changed.
-- `$pickADateDirty` - true once date has been changed.
-
 ### Credits
 
 This project is initially based on a [blog post from Coding Insight](http://www.codinginsight.com/angularjs-and-pickadate/)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,13 @@ If you find yourself setting the same options for multiple date pickers, you can
     }]);
   ```
 
+### ngModel / Angular Form Validation Expectation Management
+
+In order to correct how the pickadate plugin affects ngModel states of its assigned input, ng-pickadate manipulates ngModel form validation in order to restore expected form validation states. The unexpected angular validation states caused by the pickadate jquery plugin, and how they've been corrected, are as follows:
+
+- When pickadate is initialized on an input, this triggers the input's ngModel to be marked as $dirty. -> To correct this, the ng-pickadate directives set ngModel to $pristine at end of (post)link.
+- When pickadate calendar opens, the input itself loses focus and its ngModel is marked as $touched. -> To correct this, the directives set ngModel to $untouched the first time the calendar opens, and sets to $touched whenever the calendar closes, via pickadate's onOpen and onClose methods, respectively.
+
 ### Credits
 
 This project is initially based on a [blog post from Coding Insight](http://www.codinginsight.com/angularjs-and-pickadate/)

--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -10,7 +10,9 @@
   angular.module('pickadate').directive('pickADate', ['$parse', 'pickADate', function ($parse, pickADate) {
     return {
       restrict: 'A',
-      link: function (scope, element, attrs) {
+      require: '?ngModel',
+      link: function (scope, element, attrs, ngModel) {
+        var hasOnOpenRun = false;
         var model = {
           pickADate: $parse(attrs.pickADate),
           minDate: $parse(attrs.minDate),
@@ -51,7 +53,29 @@
           });
         };
 
+        options.onOpen = function (e) {
+          if (ngModel) {
+            if (!hasOnOpenRun) {
+              hasOnOpenRun = true;
+              scope.$apply(function () {
+                ngModel.$setUntouched();
+              });
+            }
+          }
+          if (userOptions && userOptions.onOpen) {
+            userOptions.onOpen.apply(this, arguments);
+          }
+          if (defaultOptions && defaultOptions.onOpen) {
+            defaultOptions.onOpen.apply(this, arguments);
+          }
+        };
+
         options.onClose = function () {
+          if (ngModel) {
+            scope.$applyAsync(function () {
+              ngModel.$setTouched();
+            });
+          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }
@@ -93,6 +117,10 @@
             updateValue(newValues[0]);
           }
         }, true);
+
+        if (ngModel) {
+          ngModel.$setPristine();
+        }
       }
     };
   }]);
@@ -100,7 +128,9 @@
   angular.module('pickadate').directive('pickATime', ['$parse', 'pickATime', function ($parse, pickATime) {
     return {
       restrict: 'A',
-      link: function (scope, element, attrs) {
+      require: '?ngModel',
+      link: function (scope, element, attrs, ngModel) {
+        var hasOnOpenRun = false;
         var model = {
           pickATime: $parse(attrs.pickATime),
           pickATimeOptions: $parse(attrs.pickATimeOptions)
@@ -142,7 +172,29 @@
           });
         };
 
+        options.onOpen = function () {
+          if (ngModel) {
+            if (!hasOnOpenRun) {
+              hasOnOpenRun = true;
+              scope.$apply(function () {
+                ngModel.$setUntouched();
+              });
+            }
+          }
+          if (userOptions && userOptions.onOpen) {
+            userOptions.onOpen.apply(this, arguments);
+          }
+          if (defaultOptions && defaultOptions.onOpen) {
+            defaultOptions.onOpen.apply(this, arguments);
+          }
+        };
+
         options.onClose = function () {
+          if (ngModel) {
+            scope.$applyAsync(function () {
+              ngModel.$setTouched();
+            });
+          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }
@@ -172,6 +224,10 @@
           }
           updateValue(newValue);
         }, true);
+
+        if (ngModel) {
+          ngModel.$setPristine();
+        }
       }
     };
   }]);
@@ -242,4 +298,3 @@
     this.$get.$inject = [];
   }
 })(angular);
-

--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -56,7 +56,7 @@
             userOptions.onClose.apply(this, arguments);
           }
           if (defaultOptions && defaultOptions.onClose) {
-            defaultOptions.onClose.apply(that, args);
+            defaultOptions.onClose.apply(this, arguments);
           }
           element.blur();
         };
@@ -147,7 +147,7 @@
             userOptions.onClose.apply(this, arguments);
           }
           if (defaultOptions && defaultOptions.onClose) {
-            defaultOptions.onClose.apply(that, args);
+            defaultOptions.onClose.apply(this, arguments);
           }
           element.blur();
         };

--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -10,10 +10,7 @@
   angular.module('pickadate').directive('pickADate', ['$parse', 'pickADate', function ($parse, pickADate) {
     return {
       restrict: 'A',
-      require: '?ngModel',
-      link: function (scope, element, attrs, ngModel) {
-        var onSetRunCount = 0;
-        var initOnSetRuns = 3;
+      link: function (scope, element, attrs) {
         var model = {
           pickADate: $parse(attrs.pickADate),
           minDate: $parse(attrs.minDate),
@@ -25,41 +22,12 @@
         var userOptions = model.pickADateOptions(scope) || {};
         var options = angular.extend({}, defaultOptions, userOptions);
 
-        if (ngModel) {
-          ngModel.$setPickADatePristine = function () {
-            ngModel.$pickADatePristine = true;
-            ngModel.$pickADateDirty = false;
-          }
-          ngModel.$setPickADateDirty = function () {
-            ngModel.$pickADatePristine = false;
-            ngModel.$pickADateDirty = true;
-          }
-          ngModel.$setPickADateUntouched = function () {
-            ngModel.$pickADateUntouched = true;
-            ngModel.$pickADateTouched = false;
-          }
-          ngModel.$setPickADateTouched = function () {
-            ngModel.$pickADateUntouched = false;
-            ngModel.$pickADateTouched = true;
-          }
-
-          ngModel.$setPickADatePristine();
-          ngModel.$setPickADateUntouched();
-        }
-
         options.onSet = function (e) {
           var that = this,
               args = arguments,
               select = element.pickadate('picker').get('select'); // selected date
 
           scope.$evalAsync(function () {
-            if (onSetRunCount < initOnSetRuns) {
-              onSetRunCount += 1;
-            } else {
-              if (ngModel) {
-                ngModel.$setPickADateDirty();
-              }
-            }
             if (e.hasOwnProperty('clear')) {
               model.pickADate.assign(scope, null);
               return;
@@ -84,11 +52,6 @@
         };
 
         options.onClose = function () {
-          if (ngModel) {
-            scope.$applyAsync(function () {
-              ngModel.$setPickADateTouched();
-            });
-          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }
@@ -137,10 +100,7 @@
   angular.module('pickadate').directive('pickATime', ['$parse', 'pickATime', function ($parse, pickATime) {
     return {
       restrict: 'A',
-      require: '?ngModel',
-      link: function (scope, element, attrs, ngModel) {
-        var onSetRunCount = 0;
-        var initOnSetRuns = 3;
+      link: function (scope, element, attrs) {
         var model = {
           pickATime: $parse(attrs.pickATime),
           pickATimeOptions: $parse(attrs.pickATimeOptions)
@@ -150,41 +110,12 @@
         var userOptions = model.pickATimeOptions(scope) || {};
         var options = angular.extend({}, defaultOptions, userOptions);
 
-        if (ngModel) {
-          ngModel.$setPickADatePristine = function () {
-            ngModel.$pickADatePristine = true;
-            ngModel.$pickADateDirty = false;
-          }
-          ngModel.$setPickADateDirty = function () {
-            ngModel.$pickADatePristine = false;
-            ngModel.$pickADateDirty = true;
-          }
-          ngModel.$setPickADateUntouched = function () {
-            ngModel.$pickADateUntouched = true;
-            ngModel.$pickADateTouched = false;
-          }
-          ngModel.$setPickADateTouched = function () {
-            ngModel.$pickADateUntouched = false;
-            ngModel.$pickADateTouched = true;
-          }
-
-          ngModel.$setPickADatePristine();
-          ngModel.$setPickADateUntouched();
-        }
-
         options.onSet = function (e) {
           var that = this,
               args = arguments,
               select = element.pickatime('picker').get('select'); // selected date
 
           scope.$evalAsync(function () {
-            if (onSetRunCount < initOnSetRuns) {
-              onSetRunCount += 1;
-            } else {
-              if (ngModel) {
-                ngModel.$setPickADateDirty();
-              }
-            }
             if (e.hasOwnProperty('clear')) {
               model.pickATime.assign(scope, null);
               return;
@@ -212,11 +143,6 @@
         };
 
         options.onClose = function () {
-          if (ngModel) {
-            scope.$applyAsync(function () {
-              ngModel.$setPickADateTouched();
-            });
-          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }

--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -10,7 +10,10 @@
   angular.module('pickadate').directive('pickADate', ['$parse', 'pickADate', function ($parse, pickADate) {
     return {
       restrict: 'A',
-      link: function (scope, element, attrs) {
+      require: '?ngModel',
+      link: function (scope, element, attrs, ngModel) {
+        var onSetRunCount = 0;
+        var initOnSetRuns = 3;
         var model = {
           pickADate: $parse(attrs.pickADate),
           minDate: $parse(attrs.minDate),
@@ -22,12 +25,41 @@
         var userOptions = model.pickADateOptions(scope) || {};
         var options = angular.extend({}, defaultOptions, userOptions);
 
+        if (ngModel) {
+          ngModel.$setPickADatePristine = function () {
+            ngModel.$pickADatePristine = true;
+            ngModel.$pickADateDirty = false;
+          }
+          ngModel.$setPickADateDirty = function () {
+            ngModel.$pickADatePristine = false;
+            ngModel.$pickADateDirty = true;
+          }
+          ngModel.$setPickADateUntouched = function () {
+            ngModel.$pickADateUntouched = true;
+            ngModel.$pickADateTouched = false;
+          }
+          ngModel.$setPickADateTouched = function () {
+            ngModel.$pickADateUntouched = false;
+            ngModel.$pickADateTouched = true;
+          }
+
+          ngModel.$setPickADatePristine();
+          ngModel.$setPickADateUntouched();
+        }
+
         options.onSet = function (e) {
           var that = this,
               args = arguments,
               select = element.pickadate('picker').get('select'); // selected date
 
           scope.$evalAsync(function () {
+            if (onSetRunCount < initOnSetRuns) {
+              onSetRunCount += 1;
+            } else {
+              if (ngModel) {
+                ngModel.$setPickADateDirty();
+              }
+            }
             if (e.hasOwnProperty('clear')) {
               model.pickADate.assign(scope, null);
               return;
@@ -52,6 +84,11 @@
         };
 
         options.onClose = function () {
+          if (ngModel) {
+            scope.$applyAsync(function () {
+              ngModel.$setPickADateTouched();
+            });
+          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }
@@ -100,7 +137,10 @@
   angular.module('pickadate').directive('pickATime', ['$parse', 'pickATime', function ($parse, pickATime) {
     return {
       restrict: 'A',
-      link: function (scope, element, attrs) {
+      require: '?ngModel',
+      link: function (scope, element, attrs, ngModel) {
+        var onSetRunCount = 0;
+        var initOnSetRuns = 3;
         var model = {
           pickATime: $parse(attrs.pickATime),
           pickATimeOptions: $parse(attrs.pickATimeOptions)
@@ -110,12 +150,41 @@
         var userOptions = model.pickATimeOptions(scope) || {};
         var options = angular.extend({}, defaultOptions, userOptions);
 
+        if (ngModel) {
+          ngModel.$setPickADatePristine = function () {
+            ngModel.$pickADatePristine = true;
+            ngModel.$pickADateDirty = false;
+          }
+          ngModel.$setPickADateDirty = function () {
+            ngModel.$pickADatePristine = false;
+            ngModel.$pickADateDirty = true;
+          }
+          ngModel.$setPickADateUntouched = function () {
+            ngModel.$pickADateUntouched = true;
+            ngModel.$pickADateTouched = false;
+          }
+          ngModel.$setPickADateTouched = function () {
+            ngModel.$pickADateUntouched = false;
+            ngModel.$pickADateTouched = true;
+          }
+
+          ngModel.$setPickADatePristine();
+          ngModel.$setPickADateUntouched();
+        }
+
         options.onSet = function (e) {
           var that = this,
               args = arguments,
               select = element.pickatime('picker').get('select'); // selected date
 
           scope.$evalAsync(function () {
+            if (onSetRunCount < initOnSetRuns) {
+              onSetRunCount += 1;
+            } else {
+              if (ngModel) {
+                ngModel.$setPickADateDirty();
+              }
+            }
             if (e.hasOwnProperty('clear')) {
               model.pickATime.assign(scope, null);
               return;
@@ -143,6 +212,11 @@
         };
 
         options.onClose = function () {
+          if (ngModel) {
+            scope.$applyAsync(function () {
+              ngModel.$setPickADateTouched();
+            });
+          }
           if (userOptions && userOptions.onClose) {
             userOptions.onClose.apply(this, arguments);
           }


### PR DESCRIPTION
I wanted a way to add visual feedback, based on the state of the inputs. But couldn't rely on the existing states (e.g. $(un)touched, $pristine, & $dirty) since $dirty is set to true from the start, and $touched is set to true as soon as you open the pickadate menu.

This is the solution I propose.

Your thoughts on this?
