### PR TITLE
allow update timepicker options from controller

### DIFF
--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -121,6 +121,19 @@
         if (ngModel) {
           ngModel.$setPristine();
         }
+
+        function updateOptions(newValue) {
+          if (typeof newValue === "object") {
+            element.pickadate('picker').set(newValue)
+          }
+        }
+
+        scope.$watch(attrs.pickADateOptions, function (newValue, oldValue) {
+          if (newValue === oldValue) {
+            return;
+          }
+          updateOptions(newValue)
+        }, true);
       }
     };
   }]);

--- a/ng-pickadate.js
+++ b/ng-pickadate.js
@@ -225,6 +225,20 @@
           updateValue(newValue);
         }, true);
 
+        function updateOptions(newValue) {
+          if (typeof newValue === "object") {
+            element.pickatime('picker').set(newValue)
+          }
+        }
+
+        scope.$watch(attrs.pickATimeOptions, function (newValue, oldValue) {
+          if (newValue === oldValue) {
+            return;
+          }
+          updateOptions(newValue)
+        }, true);
+
+
         if (ngModel) {
           ngModel.$setPristine();
         }


### PR DESCRIPTION
This PR allow to change `pick-a-time-options` from controller. See example:

```
<div ng-controller="MyController"> 
<input type="text" ng-model="skipHours" >
  <input type="text" data-ng-model="my time" required pick-a-time="curTime" pick-a-time-options="pickATimeOptions" >
</div>

controller('MyController', ['$scope', function($scope){
  $scope.skipHours = 0;
  $scope.pickATimeOptions = {disable: {[$scope.skipHours,30]}};
}])
```
